### PR TITLE
Fix the label selector to variable index

### DIFF
--- a/MMTL_BERT.py
+++ b/MMTL_BERT.py
@@ -67,9 +67,9 @@ def create_full_BERT_input(folder_path, text_column_name, label_column_name, con
         
         def get_BERT_input_for_example(datum):
 
-            if not datum[2] in list(label_map.keys()):
+            if not datum[headers.index(label_column_name)] in list(label_map.keys()):
                 # We need to add one to this as MeTaL does not accept 0 as a valid label
-                label_map[datum[2]] = len(list(label_map.values())) + 1
+                label_map[datum[headers.index(label_column_name)]] = len(list(label_map.values())) + 1
 
             # We tokenize our initial data
             tokens_a = tokenizer.tokenize(datum[headers.index(text_column_name)])


### PR DESCRIPTION
Fix the label selector to variable index, so that the index of the label column will always be selected when passed and is saved to the label map. Was not picked up in testing due to the databases being in different order between testing and production.