### PR TITLE
Set progress_bar to False

### DIFF
--- a/MMTL_BERT.py
+++ b/MMTL_BERT.py
@@ -233,7 +233,7 @@ scores = trainer.train_model(
     payloads, 
     n_epochs=NUM_EPOCHS, 
     log_every=1,
-    progress_bar=True,
+    progress_bar=False,
 )
 
 filename = OUTPUT_PATH + '/'+MODEL_NAME+'.out'


### PR DESCRIPTION
Sets the progress_bar option to False because progress bar output is maxing out the logs on server